### PR TITLE
Better error handling in submit.workfow

### DIFF
--- a/R/submit.workflow.R
+++ b/R/submit.workflow.R
@@ -125,7 +125,9 @@ submit.workflow <- function(server, model_id, site_id, pfts, start_date, end_dat
            output[[2]])
     }
     else{
-      stop("Unidentified error")
+      stop("Encountered other error.\n",
+           "Code: ", res$status_code, "\n",
+           "Message: ", httr::content(res)$error)
     }
   }
 }


### PR DESCRIPTION
Report the error code and message for "unidentified errors". For example, the old output was something like:

```
Error in submit.workflow(server, 3000000014, site_id, pfts = "temperate.Early_Hardwood",  : 
  Unidentified error
```

Now, the error is:

```
Error in submit.workflow(server, 3000000014, site_id, pfts = "temperate.Early_Hardwood",  : 
  Encountered other error.
Code: 400
Message: No models found with ID 3000000014
```