### PR TITLE
Pass additional customization list to `submit.workflow`

### DIFF
--- a/R/submit.workflow.R
+++ b/R/submit.workflow.R
@@ -14,6 +14,8 @@
 ##' @param sensitivity.analysis Whether or not to perform a sensitivity analysis. Can also take
 ##' a sensitivity setting object as input. Default: FALSE (logical or list)
 ##' @param notes Additional notes that the user need to specify for the submitted workflow. Default: NULL
+##' @param workflow_list_mods List of additional changes to be applied to the
+##'   workflow list. Passed to [utils::modifyList()]. Default = `list() (no changes)`.
 ##' @return Response obtained from the `POST /api/workflows/` endpoint
 ##' @author Tezan Sahu, Alexey Shiklomanov
 ##' @export
@@ -27,7 +29,8 @@
 ##'   end_date="2003-12-31", inputs=list(met=list(id=99000000003)))
 
 submit.workflow <- function(server, model_id, site_id, pfts, start_date, end_date, inputs, meta.analysis = list(),
-                            ensemble_size=1, sensitivity_variable = "NPP", sensitivity.analysis = FALSE, notes = NULL) {
+                            ensemble_size=1, sensitivity_variable = "NPP", sensitivity.analysis = FALSE, notes = NULL,
+                            workflow_list_mods = list()) {
   # Prepare the workflow based on the parameters set by user
   workflow <- list()
   workflow$pfts <- lapply(pfts, function(x) list(name = x))
@@ -79,6 +82,9 @@ submit.workflow <- function(server, model_id, site_id, pfts, start_date, end_dat
   if (!is.null(notes)) {
     workflow$info$notes <- notes
   }
+
+  # Apply any additional user changes (if any)
+  workflow <- modifyList(workflow, workflow_list_mods)
 
   # Submit the prepared workflow to the PEcAn API in XML format
   # NOTE: Use XML here because JSON doesn't like duplicate tags (which we use

--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -41,11 +41,21 @@ test_list <- read.csv("inst/integration-test-list.csv", comment.char = "#") %>%
   as_tibble() %>%
   # Only test models that are available on the target machine
   inner_join(models, c("model_name", "revision")) %>%
-  mutate(start_date = if_else(is.na(start_date), default_start_date, as.character(start_date)),
-         end_date = if_else(is.na(end_date), default_end_date, as.character(end_date)),
-         # TODO: Add more inputs here
-         inputs = pmap(., configure_inputs),
-         pfts = strsplit(pfts, "|", fixed = TRUE))
+  mutate(
+    start_date = if_else(is.na(start_date), default_start_date, as.character(start_date)),
+    end_date = if_else(is.na(end_date), default_end_date, as.character(end_date)),
+    # TODO: Add more inputs here
+    inputs = pmap(., configure_inputs),
+    pfts = strsplit(pfts, "|", fixed = TRUE),
+    # ED2-specific customizations
+    workflow_list_mods = if_else(
+      model_name == "ED2.2",
+      list(list(model = list(phenol.scheme = 0,
+                             ed_misc = list(output_month = 12),
+                             edin = "ED2IN.r2.2.0"))),
+      list(list())
+    )
+  )
 
 test_runs <- test_list %>%
   select_if(colnames(.) %in% names(formals(submit.workflow))) %>%

--- a/man/submit.workflow.Rd
+++ b/man/submit.workflow.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/submit.workflow.R
 \name{submit.workflow}
 \alias{submit.workflow}
-\title{Submit a PEcAn workflow using various user-defined parameters}
+\title{Submit a PEcAn workflow using various user-defined parameters
+Hits the \verb{POST /api/workflows/} API endpoint.}
 \usage{
 submit.workflow(
   server,
@@ -12,11 +13,12 @@ submit.workflow(
   start_date,
   end_date,
   inputs,
-  meta.analysis = NULL,
+  meta.analysis = list(),
   ensemble_size = 1,
   sensitivity_variable = "NPP",
   sensitivity.analysis = FALSE,
-  notes = NULL
+  notes = NULL,
+  workflow_list_mods = list()
 )
 }
 \arguments{
@@ -44,6 +46,9 @@ submit.workflow(
 a sensitivity setting object as input. Default: FALSE (logical or list)}
 
 \item{notes}{Additional notes that the user need to specify for the submitted workflow. Default: NULL}
+
+\item{workflow_list_mods}{List of additional changes to be applied to the
+workflow list. Passed to \code{\link[utils:modifyList]{utils::modifyList()}}. Default = \verb{list() (no changes)}.}
 }
 \value{
 Response obtained from the \verb{POST /api/workflows/} endpoint
@@ -62,5 +67,5 @@ res <- submit.workflow(server, model_id=1000000014, site_id=772, pfts=c("tempera
   end_date="2003-12-31", inputs=list(met=list(id=99000000003)))
 }
 \author{
-Tezan Sahu
+Tezan Sahu, Alexey Shiklomanov
 }


### PR DESCRIPTION
For any custom modifications you may want to apply. This is particularly useful for models like ED2 that have a lot of extra requirements:

```r
wf <- submit.workflow(
  server, ed_id, site_id,
  pfts = "temperate.Early_Hardwood",
  start_date = "2012-01-01",
  end_date = "2012-02-01",
  inputs = list(met = list(source = "MERRA"),
                lu = list(id = 294),
                thsum = list(id = 295),
                veg = list(id = 296),
                soil = list(id = 297)),
# Here, add extra stuff to the <model> tag
  workflow_list_mods = list(model = list(
    phenol.scheme = 0,
    ed_misc = list(output_month = 12),
    edin = "ED2IN.r2.2.0"
  ))
)
```

In https://github.com/PecanProject/rpecanapi/pull/10/commits/81e9e8df8b28d10a26e024e4c3cff9b2060aa7fe, I also modified the integration test script so it sets up the ED2 runs correctly using this mechanism.