### PR TITLE
Force na.strings="" in run-test-list script

### DIFF
--- a/inst/run-test-list.R
+++ b/inst/run-test-list.R
@@ -37,7 +37,8 @@ configure_inputs <- function(met, model_name, ...) {
   input
 }
 
-test_list <- read.csv("inst/integration-test-list.csv", comment.char = "#") %>%
+test_list <- read.csv("inst/integration-test-list.csv", comment.char = "#",
+                      na.strings = "") %>%
   as_tibble() %>%
   # Only test models that are available on the target machine
   inner_join(models, c("model_name", "revision")) %>%


### PR DESCRIPTION
Otherwise, missing dates are read as literal "", which breaks a bunch of things downstream. I think this might be an R v4+ issue because this worked fine before.
