### PR TITLE
Server URL should be robust to trailing slashes

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -12,6 +12,7 @@
 ##' @return A server object that can be passed into other functions for making requests to the PEcAn API
 ##' @export
 ##' @examples
+##' sub('^/|/$','',url) will remove one trailing slash from the url.
 ##' server <- connect(url="http://localhost:8000", username="carya", password="illinois")
 
 connect <- function(url, username=NULL, password=NULL){

--- a/R/connect.R
+++ b/R/connect.R
@@ -15,6 +15,6 @@
 ##' server <- connect(url="http://localhost:8000", username="carya", password="illinois")
 
 connect <- function(url, username=NULL, password=NULL){
-  res <- list(url=url, username=username, password=password)
+  res <- list(url=sub('^/|/$','',url), username=username, password=password)
   return(res)
 }


### PR DESCRIPTION
extra trailing slash has been eliminated from url so now, both
(IP <- "http://localhost:8000/" )  and  (IP <- "http://localhost:8000")
should work.